### PR TITLE
2023/11/23 テスト改良 ページタイトル追加

### DIFF
--- a/src/pages/LogIn/LogIn.tsx
+++ b/src/pages/LogIn/LogIn.tsx
@@ -43,6 +43,7 @@ const LogInPage = () => {
 
   return (
     <>
+      <h1 data-testid="login-title">Reactログインページ</h1>
       <input
         placeholder="ユーザ名"
         value={username}
@@ -55,6 +56,7 @@ const LogInPage = () => {
         value={password}
         onChange={(e) => setPassword(e.target.value)}
         data-testid="input-for-password"
+        type="password"
       />
       <br />
       <button onClick={clearValues} data-testid="clear-button">

--- a/src/pages/LogIn/test/Login.test.tsx
+++ b/src/pages/LogIn/test/Login.test.tsx
@@ -23,13 +23,18 @@ describe("LogInPage", () => {
   });
   describe("初期表示について", () => {
     describe("部品がすべて表示され、内容が正しいこと", () => {
+      test("ページタイトル", () => {
+        expect(screen.getByTestId("login-title")).toHaveTextContent(
+          "Reactログインページ"
+        );
+      });
       test("ユーザ名のテキストボックス", () => {
-        expect(screen.getAllByRole("textbox")[0]).toBeInTheDocument();
+        expect(screen.getByTestId("input-for-username")).toBeInTheDocument();
         expect(screen.getByPlaceholderText("ユーザ名")).toBeInTheDocument();
         expect(screen.getByPlaceholderText("ユーザ名")).toHaveValue("");
       });
       test("パスワードのテキストボックス", () => {
-        expect(screen.getAllByRole("textbox")[1]).toBeInTheDocument();
+        expect(screen.getByTestId("input-for-password")).toBeInTheDocument();
         expect(screen.getByPlaceholderText("パスワード")).toBeInTheDocument();
         expect(screen.getByPlaceholderText("パスワード")).toHaveValue("");
       });


### PR DESCRIPTION
<ul>
<li>パスワード用テキストボックスに`type="password`を追加。</li>
<li>上記に伴い、`getByRole()`できなくなったため、`data-testid`によるテストに変更。</li>
<li>ページタイトルとその表示テストを追加。</li>
</ul>