### PR TITLE
2023/11/23 ログイン成功時の画面遷移実装

### DIFF
--- a/src/pages/LogIn/LogIn.tsx
+++ b/src/pages/LogIn/LogIn.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { useUpdateEffect } from "react-use";
+import { useRouter } from "next/navigation";
+import Head from "next/head";
 
 const LogInPage = () => {
   const [username, setUsername] = useState("");
@@ -13,9 +15,10 @@ const LogInPage = () => {
     setResultText("");
   };
 
-  const logInJudger = (username: string, password: string) => {
+  const logInJudger = (username: string, password: string): boolean => {
+    let result = false;
     if (username === "koki" && password === "pass") {
-      setResultText("ログイン成功!!");
+      result = true;
     } else if (username !== "koki" && password === "pass") {
       setResultText("ユーザ名が誤っています");
     } else if (username === "koki" && password !== "pass") {
@@ -23,10 +26,16 @@ const LogInPage = () => {
     } else {
       setResultText("ユーザ名・パスワードを正しく入力してください");
     }
+    return result;
   };
+
+  const router = useRouter();
 
   const onClickLogInButton = () => {
     logInJudger(username, password);
+    if (logInJudger(username, password)) {
+      router.push("/Top/Top", "/Top/");
+    }
   };
 
   const isDisabledJudger = (username: string, password: string) => {
@@ -43,33 +52,36 @@ const LogInPage = () => {
 
   return (
     <>
+      <Head>
+        <title>ログイン</title>
+      </Head>
       <h1 data-testid="login-title">Reactログインページ</h1>
       <input
         placeholder="ユーザ名"
         value={username}
         onChange={(e) => setUsername(e.target.value)}
-        data-testid="input-for-username"
+        data-testid="login-input-for-username"
       />
       <br />
       <input
         placeholder="パスワード"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
-        data-testid="input-for-password"
+        data-testid="login-input-for-password"
         type="password"
       />
       <br />
-      <button onClick={clearValues} data-testid="clear-button">
+      <button onClick={clearValues} data-testid="login-clear-button">
         やり直す
       </button>
       <button
         onClick={onClickLogInButton}
         disabled={isDisabled}
-        data-testid="login-button"
+        data-testid="login-login-button"
       >
         ログイン
       </button>
-      <h1 data-testid="result-text">{resultText}</h1>
+      <h1 data-testid="login-result-text">{resultText}</h1>
     </>
   );
 };

--- a/src/pages/LogIn/test/Login.test.tsx
+++ b/src/pages/LogIn/test/Login.test.tsx
@@ -1,14 +1,20 @@
 import {
   cleanup,
   fireEvent,
-  getByTestId,
   render,
   screen,
   waitFor,
 } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import LogInPage from "../LogIn";
 import "@testing-library/jest-dom";
+
+jest.mock("next/navigation", () => ({
+  useRouter() {
+    return {
+      push: jest.fn(),
+    };
+  },
+}));
 
 const renderer = () => {
   render(<LogInPage />);
@@ -16,209 +22,209 @@ const renderer = () => {
 
 describe("LogInPage", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     renderer();
   });
   afterEach(() => {
     cleanup();
   });
-  describe("初期表示について", () => {
-    describe("部品がすべて表示され、内容が正しいこと", () => {
-      test("ページタイトル", () => {
-        expect(screen.getByTestId("login-title")).toHaveTextContent(
-          "Reactログインページ"
-        );
-      });
-      test("ユーザ名のテキストボックス", () => {
-        expect(screen.getByTestId("input-for-username")).toBeInTheDocument();
-        expect(screen.getByPlaceholderText("ユーザ名")).toBeInTheDocument();
-        expect(screen.getByPlaceholderText("ユーザ名")).toHaveValue("");
-      });
-      test("パスワードのテキストボックス", () => {
-        expect(screen.getByTestId("input-for-password")).toBeInTheDocument();
-        expect(screen.getByPlaceholderText("パスワード")).toBeInTheDocument();
-        expect(screen.getByPlaceholderText("パスワード")).toHaveValue("");
-      });
-      test("「やり直す」ボタン", () => {
-        expect(screen.getAllByRole("button")[0]).toBeInTheDocument();
-        expect(screen.getAllByRole("button")[0]).toHaveTextContent("やり直す");
-      });
-      test("「ログイン」ボタン", () => {
-        expect(screen.getAllByRole("button")[1]).toBeInTheDocument();
-        expect(screen.getAllByRole("button")[1]).toHaveTextContent("ログイン");
-        expect(screen.getAllByRole("button")[1]).toBeDisabled();
+  describe("表示テスト", () => {
+    describe("初期表示について", () => {
+      describe("部品がすべて表示され、内容が正しいこと", () => {
+        test("ページタイトル", () => {
+          expect(screen.getByTestId("login-title")).toHaveTextContent(
+            "Reactログインページ"
+          );
+        });
+        test("ユーザ名のテキストボックス", () => {
+          expect(
+            screen.getByTestId("login-input-for-username")
+          ).toBeInTheDocument();
+          expect(screen.getByPlaceholderText("ユーザ名")).toBeInTheDocument();
+          expect(screen.getByPlaceholderText("ユーザ名")).toHaveValue("");
+        });
+        test("パスワードのテキストボックス", () => {
+          expect(
+            screen.getByTestId("login-input-for-password")
+          ).toBeInTheDocument();
+          expect(screen.getByPlaceholderText("パスワード")).toBeInTheDocument();
+          expect(screen.getByPlaceholderText("パスワード")).toHaveValue("");
+        });
+        test("「やり直す」ボタン", () => {
+          expect(screen.getAllByRole("button")[0]).toBeInTheDocument();
+          expect(screen.getAllByRole("button")[0]).toHaveTextContent(
+            "やり直す"
+          );
+        });
+        test("「ログイン」ボタン", () => {
+          expect(screen.getAllByRole("button")[1]).toBeInTheDocument();
+          expect(screen.getAllByRole("button")[1]).toHaveTextContent(
+            "ログイン"
+          );
+          expect(screen.getAllByRole("button")[1]).toBeDisabled();
+        });
       });
     });
-  });
 
-  describe("テキストボックスに入力があった場合のボタン活性制御について", () => {
-    describe("ユーザ名のみ入力された場合", () => {
-      beforeEach(() => {
-        fireEvent.change(screen.getByTestId("input-for-username"), {
-          target: { value: "koki" },
+    describe("テキストボックスに入力があった場合のボタン活性制御について", () => {
+      describe("ユーザ名のみ入力された場合", () => {
+        beforeEach(() => {
+          fireEvent.change(screen.getByTestId("login-input-for-username"), {
+            target: { value: "koki" },
+          });
+        });
+        test("「ログイン」ボタンが非活性であること", () => {
+          expect(screen.getAllByRole("button")[1]).toBeDisabled();
         });
       });
-      test("「ログイン」ボタンが非活性であること", () => {
-        expect(screen.getAllByRole("button")[1]).toBeDisabled();
+      describe("パスワードのみ入力された場合", () => {
+        beforeEach(() => {
+          fireEvent.change(screen.getByTestId("login-input-for-password"), {
+            target: { value: "pass" },
+          });
+        });
+        test("「ログイン」ボタンが非活性であること", () => {
+          expect(screen.getAllByRole("button")[1]).toBeDisabled();
+        });
+      });
+      describe("ユーザ名・パスワードが入力された場合", () => {
+        beforeEach(() => {
+          fireEvent.change(screen.getByTestId("login-input-for-username"), {
+            target: { value: "koki" },
+          });
+          fireEvent.change(screen.getByTestId("login-input-for-password"), {
+            target: { value: "pass" },
+          });
+        });
+        test("「ログイン」ボタンが活性であること", () => {
+          expect(screen.getByTestId("login-login-button")).not.toBeDisabled();
+        });
       });
     });
-    describe("パスワードのみ入力された場合", () => {
-      beforeEach(() => {
-        fireEvent.change(screen.getByTestId("input-for-password"), {
-          target: { value: "pass" },
-        });
-      });
-      test("「ログイン」ボタンが非活性であること", () => {
-        expect(screen.getAllByRole("button")[1]).toBeDisabled();
-      });
-    });
-    describe("ユーザ名・パスワードが入力された場合", () => {
-      beforeEach(() => {
-        fireEvent.change(screen.getByTestId("input-for-username"), {
-          target: { value: "koki" },
-        });
-        fireEvent.change(screen.getByTestId("input-for-password"), {
-          target: { value: "pass" },
-        });
-      });
-      test("「ログイン」ボタンが活性であること", () => {
-        expect(screen.getByTestId("login-button")).not.toBeDisabled();
-      });
-    });
-  });
 
-  describe("「ログイン」ボタンをクリックした際の表示について", () => {
-    describe("ユーザ名・パスワード共に正しい値が入力された場合", () => {
-      beforeEach(async () => {
-        fireEvent.change(screen.getByTestId("input-for-username"), {
-          target: { value: "koki" },
+    describe("「ログイン」ボタンをクリックした際の表示について", () => {
+      describe("ユーザ名に正しい値、パスワードに正しくない値が入力された場合", () => {
+        beforeEach(async () => {
+          fireEvent.change(screen.getByTestId("login-input-for-username"), {
+            target: { value: "koki" },
+          });
+          fireEvent.change(screen.getByTestId("login-input-for-password"), {
+            target: { value: "password" },
+          });
+          await waitFor(() => {
+            expect(screen.getByTestId("login-login-button")).not.toBeDisabled();
+          });
+          fireEvent.click(screen.getByTestId("login-login-button"));
         });
-        fireEvent.change(screen.getByTestId("input-for-password"), {
-          target: { value: "pass" },
-        });
-        await waitFor(() => {
-          expect(screen.getByTestId("login-button")).not.toBeDisabled();
-        });
-        fireEvent.click(screen.getByTestId("login-button"));
-      });
-      test("表示文言が正しいこと", () => {
-        expect(screen.getByTestId("result-text")).toHaveTextContent(
-          "ログイン成功!!"
-        );
-      });
-    });
-    describe("ユーザ名に正しい値、パスワードに正しくない値が入力された場合", () => {
-      beforeEach(async () => {
-        fireEvent.change(screen.getByTestId("input-for-username"), {
-          target: { value: "koki" },
-        });
-        fireEvent.change(screen.getByTestId("input-for-password"), {
-          target: { value: "password" },
-        });
-        await waitFor(() => {
-          expect(screen.getByTestId("login-button")).not.toBeDisabled();
-        });
-        fireEvent.click(screen.getByTestId("login-button"));
-      });
-      test("表示文言が正しいこと", () => {
-        expect(screen.getByTestId("result-text")).toHaveTextContent(
-          "パスワードが誤っています"
-        );
-      });
-    });
-    describe("パスワードに正しい値、ユーザ名に正しくない値が入力された場合", () => {
-      beforeEach(async () => {
-        fireEvent.change(screen.getByTestId("input-for-username"), {
-          target: { value: "kokikoki" },
-        });
-        fireEvent.change(screen.getByTestId("input-for-password"), {
-          target: { value: "pass" },
-        });
-        await waitFor(() => {
-          expect(screen.getByTestId("login-button")).not.toBeDisabled();
-        });
-        fireEvent.click(screen.getByTestId("login-button"));
-      });
-      test("表示文言が正しいこと", () => {
-        expect(screen.getByTestId("result-text")).toHaveTextContent(
-          "ユーザ名が誤っています"
-        );
-      });
-    });
-    describe("ユーザ名・パスワード共に正しくない値が入力された場合", () => {
-      beforeEach(async () => {
-        fireEvent.change(screen.getByTestId("input-for-username"), {
-          target: { value: "kokikoki" },
-        });
-        fireEvent.change(screen.getByTestId("input-for-password"), {
-          target: { value: "password" },
-        });
-        await waitFor(() => {
-          expect(screen.getByTestId("login-button")).not.toBeDisabled();
-        });
-        fireEvent.click(screen.getByTestId("login-button"));
-      });
-      test("表示文言が正しいこと", () => {
-        expect(screen.getByTestId("result-text")).toHaveTextContent(
-          "ユーザ名・パスワードを正しく入力してください"
-        );
-      });
-    });
-  });
-
-  describe("「やり直す」ボタンをクリックした際の表示について", () => {
-    describe("テキストボックスのみ値が入力されている場合", () => {
-      beforeEach(async () => {
-        fireEvent.change(screen.getByTestId("input-for-username"), {
-          target: { value: "kokikoki" },
-        });
-        fireEvent.change(screen.getByTestId("input-for-password"), {
-          target: { value: "password" },
-        });
-        await waitFor(() => {
-          expect(screen.getByTestId("input-for-username")).toHaveValue(
-            "kokikoki"
-          );
-          expect(screen.getByTestId("input-for-password")).toHaveValue(
-            "password"
+        test("表示文言が正しいこと", () => {
+          expect(screen.getByTestId("login-result-text")).toHaveTextContent(
+            "パスワードが誤っています"
           );
         });
-        fireEvent.click(screen.getByTestId("clear-button"));
       });
-      test("テキストボックス内の値が消去されていること", () => {
-        expect(screen.getByTestId("input-for-username")).toHaveValue("");
-        expect(screen.getByTestId("input-for-password")).toHaveValue("");
-      });
-    });
-    describe("テキストボックスに値が入力され、resultTextが表示されている場合", () => {
-      beforeEach(async () => {
-        fireEvent.change(screen.getByTestId("input-for-username"), {
-          target: { value: "kokikoki" },
+      describe("パスワードに正しい値、ユーザ名に正しくない値が入力された場合", () => {
+        beforeEach(async () => {
+          fireEvent.change(screen.getByTestId("login-input-for-username"), {
+            target: { value: "kokikoki" },
+          });
+          fireEvent.change(screen.getByTestId("login-input-for-password"), {
+            target: { value: "pass" },
+          });
+          await waitFor(() => {
+            expect(screen.getByTestId("login-login-button")).not.toBeDisabled();
+          });
+          fireEvent.click(screen.getByTestId("login-login-button"));
         });
-        fireEvent.change(screen.getByTestId("input-for-password"), {
-          target: { value: "password" },
-        });
-        await waitFor(() => {
-          expect(screen.getByTestId("input-for-username")).toHaveValue(
-            "kokikoki"
-          );
-          expect(screen.getByTestId("input-for-password")).toHaveValue(
-            "password"
+        test("表示文言が正しいこと", () => {
+          expect(screen.getByTestId("login-result-text")).toHaveTextContent(
+            "ユーザ名が誤っています"
           );
         });
-        fireEvent.click(screen.getByTestId("login-button"));
-        await waitFor(() => {
-          expect(screen.getByTestId("result-text")).toHaveTextContent(
+      });
+      describe("ユーザ名・パスワード共に正しくない値が入力された場合", () => {
+        beforeEach(async () => {
+          fireEvent.change(screen.getByTestId("login-input-for-username"), {
+            target: { value: "kokikoki" },
+          });
+          fireEvent.change(screen.getByTestId("login-input-for-password"), {
+            target: { value: "password" },
+          });
+          await waitFor(() => {
+            expect(screen.getByTestId("login-login-button")).not.toBeDisabled();
+          });
+          fireEvent.click(screen.getByTestId("login-login-button"));
+        });
+        test("表示文言が正しいこと", () => {
+          expect(screen.getByTestId("login-result-text")).toHaveTextContent(
             "ユーザ名・パスワードを正しく入力してください"
           );
         });
-        fireEvent.click(screen.getByTestId("clear-button"));
       });
-      test("テキストボックス内の値が消去されていること", () => {
-        expect(screen.getByTestId("input-for-username")).toHaveValue("");
-        expect(screen.getByTestId("input-for-password")).toHaveValue("");
+    });
+
+    describe("「やり直す」ボタンをクリックした際の表示について", () => {
+      describe("テキストボックスのみ値が入力されている場合", () => {
+        beforeEach(async () => {
+          fireEvent.change(screen.getByTestId("login-input-for-username"), {
+            target: { value: "kokikoki" },
+          });
+          fireEvent.change(screen.getByTestId("login-input-for-password"), {
+            target: { value: "password" },
+          });
+          await waitFor(() => {
+            expect(screen.getByTestId("login-input-for-username")).toHaveValue(
+              "kokikoki"
+            );
+            expect(screen.getByTestId("login-input-for-password")).toHaveValue(
+              "password"
+            );
+          });
+          fireEvent.click(screen.getByTestId("login-clear-button"));
+        });
+        test("テキストボックス内の値が消去されていること", () => {
+          expect(screen.getByTestId("login-input-for-username")).toHaveValue(
+            ""
+          );
+          expect(screen.getByTestId("login-input-for-password")).toHaveValue(
+            ""
+          );
+        });
       });
-      test("resultTextが消去されていること", () => {
-        expect(screen.getByTestId("result-text")).toHaveTextContent("");
+      describe("テキストボックスに値が入力され、resultTextが表示されている場合", () => {
+        beforeEach(async () => {
+          fireEvent.change(screen.getByTestId("login-input-for-username"), {
+            target: { value: "kokikoki" },
+          });
+          fireEvent.change(screen.getByTestId("login-input-for-password"), {
+            target: { value: "password" },
+          });
+          await waitFor(() => {
+            expect(screen.getByTestId("login-input-for-username")).toHaveValue(
+              "kokikoki"
+            );
+            expect(screen.getByTestId("login-input-for-password")).toHaveValue(
+              "password"
+            );
+          });
+          fireEvent.click(screen.getByTestId("login-login-button"));
+          await waitFor(() => {
+            expect(screen.getByTestId("login-result-text")).toHaveTextContent(
+              "ユーザ名・パスワードを正しく入力してください"
+            );
+          });
+          fireEvent.click(screen.getByTestId("login-clear-button"));
+        });
+        test("テキストボックス内の値が消去されていること", () => {
+          expect(screen.getByTestId("login-input-for-username")).toHaveValue(
+            ""
+          );
+          expect(screen.getByTestId("login-input-for-password")).toHaveValue(
+            ""
+          );
+        });
+        test("resultTextが消去されていること", () => {
+          expect(screen.getByTestId("login-result-text")).toHaveTextContent("");
+        });
       });
     });
   });

--- a/src/pages/Top/Top.tsx
+++ b/src/pages/Top/Top.tsx
@@ -1,0 +1,27 @@
+import Head from "next/head";
+import { useRouter } from "next/navigation";
+
+const TopPage = () => {
+  const router = useRouter();
+  const onClickLogInAgainButton = () => {
+    router.push("/LogIn/LogIn", "/Login/");
+  };
+
+  return (
+    <>
+      <Head>
+        <title>トップ</title>
+      </Head>
+      <h1 data-testid="top-title">Reactトップページ</h1>
+      <h3 data-testid="top-text">ログイン御苦労。</h3>
+      <button
+        onClick={onClickLogInAgainButton}
+        data-testid="top-login-again-button"
+      >
+        もう一度ログインする
+      </button>
+    </>
+  );
+};
+
+export default TopPage;

--- a/src/pages/Top/test/Top.test.tsx
+++ b/src/pages/Top/test/Top.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import TopPage from "../Top";
+
+import "@testing-library/jest-dom";
+
+jest.mock("next/navigation", () => ({
+  useRouter() {
+    return {
+      push: jest.fn(),
+    };
+  },
+}));
+
+const renderer = () => {
+  render(<TopPage />);
+};
+
+describe("TopPage", () => {
+  beforeEach(() => {
+    renderer();
+  });
+  describe("表示テスト", () => {
+    describe("初期表示について", () => {
+      describe("部品がすべて表示され、内容が正しいこと", () => {
+        test("ページタイトル", () => {
+          expect(screen.getByTestId("top-title")).toHaveTextContent(
+            "Reactトップページ"
+          );
+        });
+        test("テキスト", () => {
+          expect(screen.getByTestId("top-text")).toHaveTextContent(
+            "ログイン御苦労。"
+          );
+        });
+        test("「もう一度ログインする」ボタン", () => {
+          expect(screen.getByRole("button")).toHaveTextContent(
+            "もう一度ログインする"
+          );
+          expect(
+            screen.getByTestId("top-login-again-button")
+          ).not.toBeDisabled();
+        });
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2133,6 +2133,11 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@remix-run/router@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.13.0.tgz#7e29c4ee85176d9c08cb0f4456bff74d092c5065"
+  integrity sha512-5dMOnVnefRsl4uRnAdoWjtVTdh8e6aZqgM4puy9nmEADH72ck+uXwzpJLEKE9Q6F8ZljNewLgmTfkxUrBdv4WA==
+
 "@rushstack/eslint-patch@^1.3.3":
   version "1.5.1"
   resolved "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.5.1.tgz"
@@ -9531,6 +9536,20 @@ react-element-to-jsx-string@^15.0.0:
     is-plain-object "5.0.0"
     react-is "18.1.0"
 
+react-fast-compare@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
+
+react-helmet-async@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-2.0.1.tgz#c97e53d03bfe578011e4abbd61113321b0362471"
+  integrity sha512-SFvEqfhFpLr5xqU6fWFb8wjVPjOR4A5skkNVNN5gAr/QeHutfDe4m1Cdo521umTiFRAY8hDOcl4xJO8sXN1n2Q==
+  dependencies:
+    invariant "^2.2.4"
+    react-fast-compare "^3.2.2"
+    shallowequal "^1.1.0"
+
 react-inspector@^6.0.0:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-6.0.2.tgz#aa3028803550cb6dbd7344816d5c80bf39d07e9d"
@@ -9589,6 +9608,21 @@ react-remove-scroll@2.5.5:
     tslib "^2.1.0"
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
+
+react-router-dom@^6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.20.0.tgz#7b9527a1e29c7fb90736a5f89d54ca01f40e264b"
+  integrity sha512-CbcKjEyiSVpA6UtCHOIYLUYn/UJfwzp55va4yEfpk7JBN3GPqWfHrdLkAvNCcpXr8QoihcDMuk0dzWZxtlB/mQ==
+  dependencies:
+    "@remix-run/router" "1.13.0"
+    react-router "6.20.0"
+
+react-router@6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.20.0.tgz#4275a3567ecc55f7703073158048db10096bb539"
+  integrity sha512-pVvzsSsgUxxtuNfTHC4IxjATs10UaAtvLGVSA1tbUE4GDaOSU1Esu2xF5nWLz7KPiMuW8BJWuPFdlGYJ7/rW0w==
+  dependencies:
+    "@remix-run/router" "1.13.0"
 
 react-style-singleton@^2.2.1:
   version "2.2.1"
@@ -10171,6 +10205,11 @@ shallow-clone@^3.0.0:
   integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
+
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<ul>
<li>ログインに成功した際に、トップページに遷移するよう実装。</li>
<li>`next/navigation`の`useRouter()`を用い、パス指定で遷移。</li>
<li>`push([遷移先パス], [タブ表示パス])`を使用。</li>
</ul>